### PR TITLE
Refactor ht backends incl. py3 support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ The following people have contributed to django-health-check:
 - Pamela McA'Nulty
 - Stefan Foulis
 - Christian Pedersen
+- Johannes Hoppe

--- a/health_check/__init__.py
+++ b/health_check/__init__.py
@@ -41,6 +41,7 @@ def autodiscover():
             if module_has_submodule(mod, 'plugin_health_check'):
                 raise
 
+
 def get_version(short=False):
     assert __version_info__['releaselevel'] in ('alpha', 'beta', 'final')
     vers = ["%(major)i.%(minor)i" % __version_info__, ]
@@ -49,5 +50,6 @@ def get_version(short=False):
     if __version_info__['releaselevel'] != 'final' and not short:
         vers.append('%s%i' % (__version_info__['releaselevel'][0], __version_info__['serial']))
     return ''.join(vers)
+
 
 __version__ = get_version()

--- a/health_check/backends/base.py
+++ b/health_check/backends/base.py
@@ -1,4 +1,10 @@
+import logging
+
+from django.utils.encoding import force_text
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
+
+logger = logging.getLogger('health-check')
 
 
 class HealthCheckStatusType(object):
@@ -6,46 +12,48 @@ class HealthCheckStatusType(object):
     working = 1
     unexpected_result = 2
 
-HEALTH_CHECK_STATUS_TYPE_TRANSLATOR = {
-    0: _("unavailable"),
-    1: _("working"),
-    2: _("unexpected result"),
-}
-
 
 class HealthCheckException(Exception):
-    pass
+    type = _("unknown error")
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return "%s: %s" % (self.type, self.message)
 
 
 class ServiceUnavailable(HealthCheckException):
-    message = HEALTH_CHECK_STATUS_TYPE_TRANSLATOR[0]
-    code = 0
+    type = _("unavailable")
 
 
 class ServiceReturnedUnexpectedResult(HealthCheckException):
-    message = HEALTH_CHECK_STATUS_TYPE_TRANSLATOR[2]
-    code = 2
+    type = _("unexpected result")
 
 
 class BaseHealthCheckBackend(object):
+    error = _("unknown error")
 
     def check_status(self):
         return None
 
-    @property
+    @cached_property
     def status(self):
-        if not getattr(self, "_status", False):
-            try:
-                setattr(self, "_status", self.check_status())
-            except (ServiceUnavailable, ServiceReturnedUnexpectedResult) as e:
-                setattr(self, "_status", e.code)
-
-        return self._status
+        try:
+            self.check_status()
+        except Exception as e:
+            logger.exception("Health check failed!")
+            self.error = e
+            return 0
+        else:
+            return 1
 
     def pretty_status(self):
-        return u"%s" % (HEALTH_CHECK_STATUS_TYPE_TRANSLATOR[self.status])
+        if self.status:
+            return _('working')
+        else:
+            return force_text(self.error)
 
     @classmethod
     def identifier(cls):
         return cls.__name__
-

--- a/health_check/plugins.py
+++ b/health_check/plugins.py
@@ -2,11 +2,14 @@
 
 from health_check.backends.base import BaseHealthCheckBackend
 
+
 class AlreadyRegistered(Exception):
     pass
 
+
 class NotRegistered(Exception):
     pass
+
 
 class HealthCheckPluginDirectory(object):
     """
@@ -18,7 +21,7 @@ class HealthCheckPluginDirectory(object):
     """
 
     def __init__(self):
-        self._registry = {} # model_class class -> admin_class instance
+        self._registry = {}  # model_class class -> admin_class instance
 
     def register(self, plugin, admin_class=None, **options):
         """

--- a/health_check/templates/health_check/dashboard.html
+++ b/health_check/templates/health_check/dashboard.html
@@ -2,18 +2,17 @@
 <head>
     <title>System status</title>
     <style>
-        html, body
-        {
+        html, body {
             margin: 0px;
             padding: 0px;
         }
-        body
-        {
+
+        body {
             background-color: #ddd;
             font-family: 'Arial', sans-serif;
         }
-        .container
-        {
+
+        .container {
             background-color: #fff;
             border: 1px solid #ccc;
             margin: auto;
@@ -21,24 +20,24 @@
             margin-top: 50px;
             padding: 15px;
         }
-        table
-        {
+
+        table {
             width: 100%;
         }
-        h1
-        {
+
+        h1 {
             font-family: 'Helvetica Neue', 'Helvetica', 'Arial', sans-serif;
             font-size: 22px;
         }
-        td.status_1, td.status_True
-        {
+
+        td.status_1 {
             background-color: #0f0;
             width: 2px;
             padding: 0px;
             margin: 0px;
         }
-        td.status_0
-        {
+
+        td.status_0 {
             background-color: #f00;
             width: 2px;
             padding: 0px;
@@ -47,17 +46,17 @@
     </style>
 </head>
 <body>
-    <div class="container">
+<div class="container">
     <h1>System status</h1>
-        <table>
+    <table>
         {% for plugin in plugins %}
-            <tr>
-                <td class="status_{{ plugin.status }}"></td>
-                <td>{{ plugin.identifier }}</td>
-                <td>{{ plugin.pretty_status }}</td>
-            </tr>
+        <tr>
+            <td class="status_{{ plugin.status }}"></td>
+            <td>{{ plugin.identifier }}</td>
+            <td>{{ plugin.pretty_status }}</td>
+        </tr>
         {% endfor %}
-        </table>
-    </div>
+    </table>
+</div>
 </body>
 </html>

--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import patterns, url
 
 import health_check
+
 health_check.autodiscover()
 
 urlpatterns = patterns('',
-    url(r'^$', 'health_check.views.home', name='health_check_home'),
-)
+                       url(r'^$', 'health_check.views.home', name='health_check_home'),
+                       )

--- a/health_check/utils.py
+++ b/health_check/utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.db.models.options import get_verbose_name
-from health_check.backends.base import HealthCheckStatusType, BaseHealthCheckBackend
+
+from health_check.backends.base import BaseHealthCheckBackend
 from health_check.plugins import plugin_dir
 
 
@@ -23,11 +24,13 @@ def healthcheck(func_or_name):
             if something_is_not_available():
                 raise ServiceUnavailable()
     """
+
     def inner(func):
         cls = type(func.__name__, (BaseHealthCheck,), {'_wrapped': staticmethod(func)})
         cls.identifier = name
         plugin_dir.register(cls)
         return func
+
     if callable(func_or_name):
         name = get_verbose_name(func_or_name.__name__).replace('_', ' ')
         return inner(func_or_name)

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,5 +1,6 @@
 from django.http import HttpResponse, HttpResponseServerError
 from django.template import loader
+
 from health_check.plugins import plugin_dir
 
 

--- a/health_check_cache/plugin_health_check.py
+++ b/health_check_cache/plugin_health_check.py
@@ -3,20 +3,17 @@ from health_check.backends.base import BaseHealthCheckBackend, ServiceUnavailabl
 from health_check.plugins import plugin_dir
 from django.core.cache import cache
 
+
 class CacheBackend(BaseHealthCheckBackend):
 
     def check_status(self):
         try:
             cache.set('djangohealtcheck_test', 'itworks', 1)
-            if cache.get("djangohealtcheck_test") == "itworks":
-                return True
-            else:
+            if not cache.get("djangohealtcheck_test") == "itworks":
                 raise ServiceUnavailable("Cache key does not match")
-        except CacheKeyWarning:
-            raise ServiceReturnedUnexpectedResult("Cache key warning")
-        except ValueError:
-            raise ServiceReturnedUnexpectedResult("ValueError")
-        except Exception:
-            raise ServiceUnavailable("Unknown exception")
+        except CacheKeyWarning as e:
+            raise ServiceReturnedUnexpectedResult("Cache key warning") from e
+        except ValueError as e:
+            raise ServiceReturnedUnexpectedResult("ValueError") from e
 
 plugin_dir.register(CacheBackend)

--- a/health_check_celery/plugin_health_check.py
+++ b/health_check_celery/plugin_health_check.py
@@ -18,7 +18,7 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             now = datetime.now()
             while (now + timedelta(seconds=3)) > datetime.now():
                 if result.result == 8:
-                    return True
+                    return
                 sleep(0.5)
         except IOError:
             pass

--- a/health_check_celery3/plugin_health_check.py
+++ b/health_check_celery3/plugin_health_check.py
@@ -17,10 +17,10 @@ class CeleryHealthCheck(BaseHealthCheckBackend):
             result = add.apply_async(args=[4, 4], expires=datetime.now() + timedelta(seconds=timeout))
             now = datetime.now()
             while (now + timedelta(seconds=3)) > datetime.now():
-                print "            checking...."
+                print("            checking....")
                 if result.ready():
                     result.forget()
-                    return True
+                    return
                 sleep(0.5)
         except IOError:
             pass

--- a/health_check_db/plugin_health_check.py
+++ b/health_check_db/plugin_health_check.py
@@ -11,7 +11,6 @@ class DjangoDatabaseBackend(BaseHealthCheckBackend):
             obj.title = "newtest"
             obj.save()
             obj.delete()
-            return True
         except IntegrityError:
             raise ServiceReturnedUnexpectedResult("Integrity Error")
         except DatabaseError:


### PR DESCRIPTION
The error reportring didn't help much
as most error messages where caught and overwritten.
Errors that weren't caught resulted in real server error.
Additinally `status_check` returned a status code in addition
to raising errors.

`status_check` only raies errors now or returns `None` if everything
is already. Similar to how `ValidationErrors` are handle in Django.
You may raise a `HealthCheckError` at any time and it will be properly
caught and displayed in the health check view.

Other, or unexpected Exceptions are still caught and displayed, for
the health check view to never be down.

Additinally logging was added to get a better insight including a
stack trace to where the Exception was raised.

This change may only work in python 3.